### PR TITLE
fix: don't close docsetting when opened with openSettingsFile

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -102,7 +102,7 @@ function ComicMeta:onComicMeta()
                 end
 
                 -- Retrieve current metadata
-                local doc_settings = DocSettings:openSettingsFile(file_path)
+                local doc_settings = DocSettings.openSettingsFile(file_path)
                 if not doc_settings then
                     UIManager:show(InfoMessage:new{
                         text = _("Failed to open DocSettings for file: ") .. file,
@@ -130,7 +130,6 @@ function ComicMeta:onComicMeta()
 
                 -- Save the updated metadata back to the metadata file
                 doc_settings:flushCustomMetadata(file_path)
-                doc_settings:close()
 
                 -- Update the book info in the file manager
                 UIManager:broadcastEvent(Event:new("BookInfoChanged", file_path))


### PR DESCRIPTION
This is not supported, see https://github.com/koreader/koreader/blob/2512f06eb06e6d6acfebff163d64a85e8762c5fd/frontend/docsettings.lua#L299

Fixes: https://github.com/NightQuest/comicmeta.koplugin/issues/2
Change-Id: 271956eba175cd4649017db45183be8a

---

I've also reverted f08b0c6c3cb91ab0feddd5c0a180cad3429c8200, as Koreader creates the sidecar file when you flush if it doesn't exist.

---

![Animation](https://github.com/user-attachments/assets/0cc7ae9c-f928-4fd9-b848-0e0da4e816f1)
