### PR TITLE
feat: add native xml support

### DIFF
--- a/.github/workflows/lua-busted.yml
+++ b/.github/workflows/lua-busted.yml
@@ -6,5 +6,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Run Busted
         uses: lunarmodules/busted@v2.2.0
+        env:
+          LUA_PATH: "./?.lua;./lib/?.lua;"
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/slaxml"]
+	path = third_party/slaxml
+	url = https://github.com/Phrogz/SLAXML.git

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: test
+
+LUA_PATH := ./?.lua;./lib/?.lua;
+
+test:
+	LUA_PATH="$(LUA_PATH)" busted .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 # comicmeta.koplugin
+
 Plugin for KOReader to extract metadata from .cbz files as Custom Metadata
 
+## Example
 
-# Example
 https://github.com/user-attachments/assets/dbedf7fa-b5df-4536-8686-919342ff41ce
 
+## Contributing
+
+### Running Test
+
+To run test, you can run `make` in the root dir of the project.
+
+```shell
+❯ make
+LUA_PATH="./?.lua;./lib/?.lua;" busted .
+●●●●●●
+6 successes / 0 failures / 0 errors / 0 pending : 0.002076 seconds
+```
+
+To run test, [busted](https://github.com/lunarmodules/busted) is used.

--- a/lib/xml.lua
+++ b/lib/xml.lua
@@ -1,0 +1,113 @@
+local SLAXML = require("third_party.slaxml.slaxml")
+
+local XmlObject = {}
+XmlObject.__index = XmlObject
+
+function XmlObject:new()
+    local o = {
+        root = nil,
+        stack = {},
+    }
+    setmetatable(o, self)
+    return o
+end
+
+-- Parses XML string into Lua table object
+function XmlObject:parse(xml)
+    local currentNode = {}
+
+    local parser = SLAXML:parser({
+        startElement = function(name, nsURI, nsPrefix)
+            local node = {
+                _name = name,
+                _children = {},
+                _text = "",
+                _attr = {},
+            }
+
+            if not self.root then
+                self.root = node
+            else
+                -- Add this node as child of currentNode
+                table.insert(currentNode._children, node)
+            end
+
+            -- Push current node on stack and update currentNode
+            table.insert(self.stack, node)
+            currentNode = node
+        end,
+
+        attribute = function(name, value, nsURI, nsPrefix)
+            if currentNode then
+                if currentNode._attr then
+                    currentNode._attr[name] = value
+                else
+                    currentNode._attr = {}
+                    currentNode._attr[name] = value
+                end
+            end
+        end,
+
+        text = function(text)
+            if currentNode then
+                if currentNode._text then
+                    currentNode._text = currentNode._text .. text
+                else
+                    currentNode._text = text
+                end
+            end
+        end,
+
+        closeElement = function(name)
+            currentNode = table.remove(self.stack)
+            currentNode = self.stack[#self.stack] -- parent node or nil if closed root
+        end,
+    })
+
+    parser:parse(xml)
+    return self.root
+end
+
+-- Helper: converts parsed tree to a cleaner table
+-- Children with unique names become keys; multiple children same name become arrays
+function XmlObject:toTable(node)
+    if not node then
+        return nil
+    end
+
+    local obj = {}
+
+    -- Merge attributes first
+    for k, v in pairs(node._attr) do
+        obj[k] = v
+    end
+
+    -- Process children
+    local childrenByName = {}
+    for _, child in ipairs(node._children) do
+        childrenByName[child._name] = childrenByName[child._name] or {}
+        table.insert(childrenByName[child._name], self:toTable(child))
+    end
+
+    for name, list in pairs(childrenByName) do
+        if #list == 1 then
+            obj[name] = list[1]
+        else
+            obj[name] = list
+        end
+    end
+
+    -- Add text if present and no children or attributes
+    local text = node._text:match("^%s*(.-)%s*$")
+    if text ~= "" then
+        if next(obj) == nil then
+            return text
+        else
+            obj["text"] = text
+        end
+    end
+
+    return obj
+end
+
+return XmlObject

--- a/test/slaxml_spec.lua
+++ b/test/slaxml_spec.lua
@@ -1,0 +1,60 @@
+local SLAXML = require("third_party.slaxml.slaxml")
+
+describe("slaxml XML Parsing", function()
+    local itemContents
+
+    before_each(function()
+        itemContents = {}
+        local currentElement = nil
+        local currentAttributes = {}
+
+        local parser = SLAXML:parser({
+            startElement = function(name, nsURI, nsPrefix)
+                currentElement = name
+            end,
+
+            attribute = function(name, value, nsURI, nsPrefix)
+                currentAttributes[name] = value
+            end,
+
+            closeElement = function(name)
+                currentElement = nil
+                currentAttributes = {}
+            end,
+
+            text = function(text)
+                text = text:match("^%s*(.-)%s*$")
+                if currentElement == "item" and text ~= "" then
+                    table.insert(itemContents, {
+                        text = text,
+                        attrs = currentAttributes,
+                    })
+                end
+            end,
+        })
+
+        local xml = [[
+    <root>
+      <item okay="yes">Hello</item>
+      <item okay="no">World</item>
+    </root>
+    ]]
+        parser:parse(xml)
+    end)
+
+    it("parses two <item> elements", function()
+        assert.are.equal(2, #itemContents)
+    end)
+
+    it("parses correct text content", function()
+        assert.are.equal("Hello", itemContents[1].text)
+        assert.are.equal("World", itemContents[2].text)
+    end)
+
+    it("parses attributes correctly", function()
+        -- NOTE: this is a hack to pretty print the table :sob:
+        -- assert.are.same(itemContents, nil)
+        assert.are.equal("yes", itemContents[1].attrs.okay)
+        assert.are.equal("no", itemContents[2].attrs.okay)
+    end)
+end)

--- a/test/xml_spec.lua
+++ b/test/xml_spec.lua
@@ -1,0 +1,29 @@
+local XmlObject = require("lib.xml")
+
+describe("xml object", function()
+    describe("parse sample", function()
+        local xml = [[
+    <root>
+      <item okay="yes">Hello</item>
+      <item okay="no">World</item>
+    </root>
+    ]]
+
+        local parser = XmlObject:new()
+        local root = parser:parse(xml)
+        local obj = parser:toTable(root)
+
+        it("should have 2 items", function()
+            -- NOTE: this is a hack to pretty print the table :sob:
+            -- assert.are.equal(obj, nil)
+            assert.are.equal(#obj.item, 2)
+        end)
+        it("should have text HelloWorld", function()
+            assert.are.equal(obj.item[1].text .. obj.item[2].text, "HelloWorld")
+        end)
+        it("should have attributes okay=yes/no", function()
+            assert.are.equal(obj.item[1].okay, "yes")
+            assert.are.equal(obj.item[2].okay, "no")
+        end)
+    end)
+end)


### PR DESCRIPTION
This should make it easier to parse the xml file and get more information out of it.

This is done by adding a new git submodule for https://github.com/Phrogz/SLAXML and adds a few basic tests to show case how it works.

These test files are executed using `busted`.

Relates-To: https://github.com/NightQuest/comicmeta.koplugin/issues/1

Change-Id: 0de6160bdc646e5c54589d46172bb0a9

---

I've also inverted the first if statement so that we lose 1 level of indentation 👀 

---

Todo:

- [x] Add some makefile to exec test
- [x] Github Action to run test 🤖 