### PR TITLE
feat(comicmeta): add recursive .cbz file processing and tests

### DIFF
--- a/test/comicmeta_spec.lua
+++ b/test/comicmeta_spec.lua
@@ -1,0 +1,49 @@
+require("test/mocks")
+
+describe("ComicMeta utility functions", function()
+    local test_root = "/tmp/comicmeta_test"
+    local subdir = test_root .. "/sub"
+    local cbz_file = test_root .. "/test.cbz"
+    local sub_cbz_file = subdir .. "/subtest.cbz"
+    local ComicMeta = require("main")
+
+    before_each(function()
+        os.execute("rm -rf " .. string.format("%q", test_root))
+
+        lfs.mkdir(test_root)
+        lfs.mkdir(subdir)
+
+        -- Create dummy .cbz files
+        local f = io.open(cbz_file, "w")
+        f:write("dummy")
+        f:close()
+
+        local f2 = io.open(sub_cbz_file, "w")
+        f2:write("dummy")
+        f2:close()
+    end)
+
+    after_each(function()
+        os.execute("rm -rf " .. string.format("%q", test_root))
+    end)
+
+    it("scanCbzFilesRecursive finds .cbz files recursively", function()
+        local files = ComicMeta:scanCbzFilesRecursive(test_root)
+
+        assert.equals(2, #files)
+    end)
+
+    it("scanCbzFilesRecursive returns empty for folder with no .cbz files", function()
+        os.remove(cbz_file)
+        os.remove(sub_cbz_file)
+
+        local files = ComicMeta:scanCbzFilesRecursive(test_root)
+
+        assert.equals(0, #files)
+    end)
+
+    it("hasSubdirectories detects subdirectories", function()
+        assert.is_true(ComicMeta:hasSubdirectories(test_root))
+        assert.is_false(ComicMeta:hasSubdirectories(subdir))
+    end)
+end)

--- a/test/mocks.lua
+++ b/test/mocks.lua
@@ -1,0 +1,132 @@
+-- Mocks for KOReader modules
+package.preload["libs/libkoreader-lfs"] = function()
+    return {
+        dir = function(path)
+            -- Returns an iterator over files and directories in the path
+            local files = {}
+            local handle = io.popen(string.format("ls -A %q", path))
+            if handle then
+                for entry in handle:lines() do
+                    table.insert(files, entry)
+                end
+                handle:close()
+            end
+            local i = 0
+            return function()
+                i = i + 1
+                return files[i]
+            end
+        end,
+        attributes = function(path)
+            -- Escape double quotes in path to prevent command injection
+            local safe_path = path:gsub('"', '\\"')
+            local stat = io.popen(string.format('stat -c "%%F" "%s"', safe_path))
+            if stat then
+                local mode = stat:read("*l")
+                stat:close()
+                if mode == "directory" then
+                    return { mode = "directory" }
+                else
+                    return { mode = "file" }
+                end
+            end
+            return nil
+        end,
+        mkdir = function(path)
+            os.execute(string.format("mkdir -p %q", path))
+            return true
+        end,
+    }
+end
+package.preload["ui/widget/confirmbox"] = function()
+    return {
+        new = function()
+            return {}
+        end,
+    }
+end
+package.preload["dispatcher"] = function()
+    return { registerAction = function() end }
+end
+package.preload["docsettings"] = function()
+    return {
+        openSettingsFile = function()
+            return {
+                readSetting = function()
+                    return {}
+                end,
+                saveSetting = function() end,
+                flushCustomMetadata = function() end,
+            }
+        end,
+    }
+end
+package.preload["ui/event"] = function()
+    return {
+        new = function()
+            return {}
+        end,
+    }
+end
+package.preload["apps/filemanager/filemanager"] = function()
+    return {
+        instance = {
+            file_chooser = { path = "/tmp/comicmeta_test" },
+        },
+    }
+end
+package.preload["ui/widget/infomessage"] = function()
+    return {
+        new = function()
+            return {}
+        end,
+    }
+end
+package.preload["ui/uimanager"] = function()
+    return {
+        show = function() end,
+        broadcastEvent = function() end,
+    }
+end
+package.preload["ui/widget/container/widgetcontainer"] = function()
+    local mt = {}
+    mt.__index = mt
+    function mt:extend(tbl)
+        setmetatable(tbl, self)
+        return tbl
+    end
+    return setmetatable({}, mt)
+end
+package.preload["ffi/util"] = function()
+    return {
+        template = function(str, ...)
+            return str
+        end,
+        realpath = function(path)
+            return path
+        end,
+    }
+end
+package.preload["logger"] = function()
+    return {
+        dbg = function(...) end,
+    }
+end
+package.preload["util"] = function()
+    return {
+        splitToArray = function(str, sep, _)
+            return {}
+        end,
+        htmlEntitiesToUtf8 = function(str)
+            return str
+        end,
+        trim = function(str)
+            return str
+        end,
+    }
+end
+package.preload["gettext"] = function()
+    return function(str)
+        return str
+    end
+end


### PR DESCRIPTION
Extend ComicMeta to process .cbz files recursively in folders.

Add scanCbzFilesRecursive, hasSubdirectories, and processAllCbz methods.

Integrate ConfirmBox for user confirmation when
subdirectories are detected.

Add unit tests for new utilities.

Fixes: https://github.com/NightQuest/comicmeta.koplugin/issues/5

Change-Id: 5f3840bfebb0cb216ace61a92ebb9f8b
Change-Id-Short: ukwrvzoklooz