### PR TITLE
feat(comicmeta): add custom ToC generation from ComicInfo.xml pages

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -105,8 +105,9 @@ function ComicMeta:processFile(cbz_file)
     end
 
     -- Retrieve current metadata
-    local doc_settings = DocSettings.openSettingsFile(cbz_file)
-    if not doc_settings then
+    local custom_doc_settings = DocSettings.openSettingsFile(cbz_file)
+    local doc_settings = DocSettings:open(cbz_file)
+    if not custom_doc_settings or not doc_settings then
         UIManager:show(InfoMessage:new({
             text = _("Failed to open DocSettings for file: ") .. cbz_file,
         }))
@@ -114,12 +115,12 @@ function ComicMeta:processFile(cbz_file)
     end
 
     -- Read the existing doc_props property
-    local doc_props = doc_settings:readSetting("doc_props") or {}
+    local doc_props = custom_doc_settings:readSetting("doc_props") or {}
     local original_doc_props = {}
     for key, __ in pairs(metadata) do
         original_doc_props[key] = doc_props[key] or ""
     end
-    doc_settings:saveSetting("doc_props", original_doc_props)
+    custom_doc_settings:saveSetting("doc_props", original_doc_props)
 
     -- Update the custom properties with the new metadata
     for key, value in pairs(metadata) do
@@ -127,10 +128,13 @@ function ComicMeta:processFile(cbz_file)
     end
 
     -- Write the updated doc_props property back to the DocSettings
-    doc_settings:saveSetting("custom_props", doc_props)
+    custom_doc_settings:saveSetting("custom_props", doc_props)
+
+    self:writeCustomToC(doc_settings, comic_metadata.Pages)
 
     -- Save the updated metadata back to the metadata file
-    doc_settings:flushCustomMetadata(cbz_file)
+    custom_doc_settings:flushCustomMetadata(cbz_file)
+    doc_settings:flush()
 
     -- Update the book info in the file manager
     UIManager:broadcastEvent(Event:new("InvalidateMetadataCache", cbz_file))
@@ -233,6 +237,65 @@ function ComicMeta:processAllCbz(folder, recursive)
 
         self:processFile(real_path)
     end
+end
+
+--- Writes a custom Table of Contents based on the Pages data from ComicInfo.xml
+--- Example xml:
+---<Pages>
+--   <Page Image="0" Type="FrontCover" Bookmark="Capa" />
+--   <Page Image="1" Type="Story" Bookmark="Capítulo 1: Paraíso" />
+--   <Page Image="71" Type="Story" Bookmark="Capítulo 2: Pseudo-criaturas" />
+--   <Page Image="112" Type="Story" Bookmark="Capítulo 3: Hospedeiros" />
+--   <Page Image="159" Type="Story" Bookmark="Capítulo 4: Purgatório" />
+-- </Pages>
+--
+-- So to access these fields:
+-- pages_data.Page[1].Image, pages_data.Page[1].Bookmark, etc.
+--
+-- For the structure of the ToC entries, see:
+-- https://github.com/koreader/koreader/blob/7e63f91c8e74af64089cefa187a17d664e261b35/frontend/apps/reader/modules/readerhandmade.lua#L23
+--
+-- @param doc_settings: The DocSettings object for the file, this must be DocSettings:open(file)
+-- @param pages_data: The Pages data from the parsed ComicInfo.xml
+function ComicMeta:writeCustomToC(doc_settings, pages_data)
+    if not pages_data or not pages_data.Page then
+        logger.dbg("ComicMeta -> writeCustomToC: No pages data found")
+
+        return
+    end
+
+    logger.dbg("ComicMeta -> writeCustomToC writing ToC from pages", #pages_data.Page)
+
+    local toc = {}
+    local pages = pages_data.Page
+
+    for _, page in ipairs(pages) do
+        if page.Bookmark and page.Bookmark ~= "" then
+            -- Convert Image attribute to page number (add 1 since it's 0-based)
+            local page_num = tonumber(page.Image)
+
+            if page_num then
+                table.insert(toc, {
+                    depth = 1,
+                    page = page_num + 1, -- Convert from 0-based to 1-based
+                    title = page.Bookmark,
+                })
+            else
+                logger.err("ComicMeta -> writeCustomToC: Invalid Image value for page", page.Image)
+            end
+        end
+    end
+
+    if #toc == 0 then
+        logger.dbg("ComicMeta -> writeCustomToC: No bookmarked pages found")
+        return
+    end
+
+    logger.dbg("ComicMeta -> writeCustomToC: Created ToC with", #toc, "entries")
+
+    doc_settings:saveSetting("handmade_toc", toc)
+    doc_settings:saveSetting("handmade_toc_enabled", true)
+    doc_settings:saveSetting("handmade_toc_edit_enabled", false)
 end
 
 function ComicMeta:onComicMeta()

--- a/test/comicmeta_spec.lua
+++ b/test/comicmeta_spec.lua
@@ -47,3 +47,55 @@ describe("ComicMeta utility functions", function()
         assert.is_false(ComicMeta:hasSubdirectories(subdir))
     end)
 end)
+
+describe("ComicMeta.writeCustomToC", function()
+    local ComicMeta = require("main")
+
+    it("saves correct ToC settings from pages data", function()
+        -- Mock doc_settings
+        local saved = {}
+        local doc_settings = {
+            saveSetting = function(_, key, value)
+                saved[key] = value
+            end
+        }
+
+        -- Example pages_data as parsed from ComicInfo.xml
+        local pages_data = {
+            Page = {
+                { Image = "0", Type = "FrontCover", Bookmark = "Capa" },
+                { Image = "1", Type = "Story", Bookmark = "Capítulo 1: Paraíso" },
+                { Image = "71", Type = "Story", Bookmark = "Capítulo 2: Pseudo-criaturas" },
+                { Image = "112", Type = "Story", Bookmark = "Capítulo 3: Hospedeiros" },
+                { Image = "159", Type = "Story", Bookmark = "Capítulo 4: Purgatório" },
+            }
+        }
+
+        ComicMeta:writeCustomToC(doc_settings, pages_data)
+
+        assert.is_true(saved.handmade_toc_enabled)
+        assert.is_false(saved.handmade_toc_edit_enabled)
+        assert.is_table(saved.handmade_toc)
+        assert.equals(5, #saved.handmade_toc)
+        assert.same(
+            { depth = 1, page = 1, title = "Capa" },
+            saved.handmade_toc[1]
+        )
+        assert.same(
+            { depth = 1, page = 2, title = "Capítulo 1: Paraíso" },
+            saved.handmade_toc[2]
+        )
+        assert.same(
+            { depth = 1, page = 72, title = "Capítulo 2: Pseudo-criaturas" },
+            saved.handmade_toc[3]
+        )
+        assert.same(
+            { depth = 1, page = 113, title = "Capítulo 3: Hospedeiros" },
+            saved.handmade_toc[4]
+        )
+        assert.same(
+            { depth = 1, page = 160, title = "Capítulo 4: Purgatório" },
+            saved.handmade_toc[5]
+        )
+    end)
+end)

--- a/test/xml_spec.lua
+++ b/test/xml_spec.lua
@@ -27,3 +27,34 @@ describe("xml object", function()
         end)
     end)
 end)
+
+describe("xml object with array", function()
+    describe("parse sample", function()
+        local xml = [[
+    <root>
+      <items>
+        <item okay="yes">Hello</item>
+        <item okay="no">World</item>
+      </items>
+    </root>
+    ]]
+
+        local parser = XmlObject:new()
+        local root = parser:parse(xml)
+        local obj = parser:toTable(root)
+
+        it("should have 2 items", function()
+            -- NOTE: this is a hack to pretty print the table :sob:
+            -- assert.are.equal(obj, nil)
+            assert.is_not_nil(obj.items)
+            assert.are.equal(#obj.items.item, 2)
+        end)
+        it("should have text HelloWorld", function()
+            assert.are.equal(obj.items.item[1].text .. obj.items.item[2].text, "HelloWorld")
+        end)
+        it("should have attributes okay=yes/no", function()
+            assert.are.equal(obj.items.item[1].okay, "yes")
+            assert.are.equal(obj.items.item[2].okay, "no")
+        end)
+    end)
+end)


### PR DESCRIPTION
Implement writeCustomToC to generate and save a custom Table of Contents
based on ComicInfo.xml page bookmarks.

Add tests to verify correct ToC creation and settings.

Also add XML array parsing tests that can be used as reference on how to
access the parsed data structure.

Change-Id: 26f88956da009ab5b5dbe2b589816481
Change-Id-Short: xtkrrqutmpzz
Fixes: https://github.com/NightQuest/comicmeta.koplugin/issues/1

---

Should be merged after #10 

---

<img width="540" height="720" alt="2025-09-15-161954_hyprshot" src="https://github.com/user-attachments/assets/381cdc06-984d-4b42-b208-3f5764ac0357" />

<img width="3398" height="1366" alt="2025-09-15-163001_hyprshot" src="https://github.com/user-attachments/assets/fc277f38-2c22-44f4-997d-b0ef371cf1a8" />
